### PR TITLE
copy files option has been added + lint and deprication changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *pycache*
 *.pyc
 *.sw*
+.idea

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-An implementation of Molecule's delegated driver to leverage an existing libvirt daemon. It's meant to be used with preconfigured  custom images or [generic cloud images such as these](https://docs.openstack.org/image-guide/obtain-images.html).
+An implementation of Molecule's delegated driver to leverage an existing
+libvirt daemon. It's meant to be used with preconfigured  custom images or
+generic cloud images
+[such as these](https://docs.openstack.org/image-guide/obtain-images.html).
 
-It is necessary to install the included **delegated.py** script since the delegated driver does not currently support the ansible_become variables required for testing scenarios where escalation is needed. [PR was submitted and approved](https://github.com/ansible/molecule/pull/1738) though not yet merged.
+It is necessary to install the included **delegated.py** script since the
+delegated driver does not currently support the ansible_become variables
+required for testing scenarios where escalation is needed. 
+[PR was submitted and approved](https://github.com/ansible/molecule/pull/1738)
+though not yet merged.
 
 
 Assumptions
@@ -8,13 +15,16 @@ Assumptions
 
 - Functioning libvirt daemon on the default qemu:///system uri.
 - The libguestfs-tools package providing virt-customize is installed.
-- Appropriate permissions for the user running Molecule on the libvirt daemon, directories, etc.
+- Appropriate permissions for the user running Molecule on the libvirt daemon, 
+directories, etc.
 
 
 Common Variables
 -----------------
 
-These can be set at the driver and platform levels. At the driver level they apply to every platform, unless set also at the platform level, which takes precendence.
+These can be set at the driver and platform levels. At the driver level they
+apply to every platform, unless set also at the platform level, which takes
+precendence.
 
 | Variable      | Type   | Default                 | Comment                                                        |
 |---------------|--------|-------------------------|----------------------------------------------------------------|
@@ -47,6 +57,7 @@ Platform Variables
 | cpu             | int    | 1                 | number of vCPU as positive integer                               |
 | extra_vol       | hash   | none, optional    | extra disk(s) to be attached to the VM with size including unit  |
 | become_pass     | string | none, optional    | password for privilege escalation if using preconfigured image   |
+| upload_files    | dict   | []                | list with upload items with `local_path` and `remote_path`       |
 
 
 Example molecule.yml
@@ -79,22 +90,34 @@ platforms:
     selinux_relabel: true
     ssh_pub: /tmp/centos_key.pub
     base_image: ~/Downloads/CentOS-7-x86_64-GenericCloud.qcow2
-provisioner:
-  name: ansible
+    upload_files:
+      - local_path: files/somefile
+        remote_path: /some/destination/folder/filename
+scenario:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-    converge: playbook.yml
-  lint:
-    name: ansible-lint
-lint:
-  name: yamllint
+    converge: converge.yml
+provisioner:
+  name: ansible
+lint: |
+    yamllint .
+    ansible-lint .
+    flake8 .
 verifier:
   name: testinfra
   env:
     PYTHONWARNINGS: "ignore:.*U.*mode is deprecated:DeprecationWarning"
-  lint:
-    name: flake8
-  options:
-    v: 1
 ```
+
+Changelog
+---------
+
+**2022.06.14:**
+
+- Copy file(s) to virtual machine image option has been added: e.g. Canonical
+[cloud images](https://cloud-images.ubuntu.com/releases/) (like Ubuntu18.04 or
+20.04) ships without netplan config to bring up ethernet interfaces, so you can
+upload them.
+- Minor code style changes according to ansible-lint, removed deprecated
+options (especially molecule.yml old structure).

--- a/converge.yml
+++ b/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: ping
+      ansible.builtin.ping:
+    - name: ping
+      ansible.builtin.ping:
+      become: true

--- a/create.yml
+++ b/create.yml
@@ -5,13 +5,14 @@
   gather_facts: false
   tasks:
     - name: call instance creation job
-      include_tasks: files/create_vm.yml
+      ansible.builtin.include_tasks: files/create_vm.yml
       vars:
         vm_name: "mlcl-{{ item.name }}"
       loop: "{{ molecule_yml.platforms }}"
       no_log: true
 
     - name: dump instance config to disk
-      copy:
+      ansible.builtin.copy:
         content: "{{ instance_conf_dict }}"
         dest: "{{ molecule_instance_config }}"
+        mode: 0644

--- a/destroy.yml
+++ b/destroy.yml
@@ -12,6 +12,6 @@
       no_log: true
 
     - name: remove instance config from disk
-      file:
+      ansible.builtin.file:
         path: "{{ molecule_instance_config }}"
         state: absent

--- a/files/50-cloud-init.yaml
+++ b/files/50-cloud-init.yaml
@@ -1,0 +1,7 @@
+---
+
+network:
+  version: 2
+  ethernets:
+    ens3:
+      dhcp4: true

--- a/files/create_vm.yml
+++ b/files/create_vm.yml
@@ -1,19 +1,19 @@
 ---
 - name: set instance variables
-  set_fact:
-    config_vm: "{{ item.config_vm|default(true) }}"
-    vm_user: "{{ item.user|default(lookup('env','USER')) }}"
+  ansible.builtin.set_fact:
+    config_vm: "{{ item.config_vm | default(true) }}"
+    vm_user: "{{ item.user | default(lookup('env', 'USER')) }}"
     img_path: "{{ molecule_yml.driver.images_path }}/{{ vm_name }}.qcow2"
-    selinux_relabel: "{{ item.selinux_relabel|default(false) }}"
-    ssh_pub: "{{ item.ssh_pub_path|default(molecule_yml.driver.ssh_pub_path)|
-      default(lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
-    root_pass: "{{ item.become_pass|default(lookup('password',
+    selinux_relabel: "{{ item.selinux_relabel | default(false) }}"
+    ssh_pub: "{{ item.ssh_pub_path | default(molecule_yml.driver.ssh_pub_path) |
+      default(lookup('env', 'HOME') + '/.ssh/id_rsa.pub') }}"
+    root_pass: "{{ item.become_pass | default(lookup('password',
       '/dev/null length=16 chars=ascii_letters')) }}"
-    down_path: "{{ molecule_yml.driver.download_path|
-      default(lookup('env','HOME')) }}"
+    down_path: "{{ molecule_yml.driver.download_path |
+      default(lookup('env', 'HOME')) }}"
 
 - name: check if the instance image exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ img_path }}"
   register: img_stat
 
@@ -22,30 +22,41 @@
     - name: deal with a URL given as base image
       block:
         - name: check if image was already downloaded
-          stat:
-            path: "{{ down_path }}/{{ item.base_image|basename }}"
+          ansible.builtin.stat:
+            path: "{{ down_path }}/{{ item.base_image | basename }}"
           register: down_stat
 
         - name: download base image
-          get_url:
+          ansible.builtin.get_url:
             url: "{{ item.base_image }}"
             dest: "{{ down_path }}"
+            mode: 0644
           when: not down_stat.stat.exists
 
         - name: make a copy of the base image to use with this instance
           synchronize:
-            src: "{{ down_path }}/{{ item.base_image|basename }}"
+            src: "{{ down_path }}/{{ item.base_image | basename }}"
             dest: "{{ img_path }}"
-      when: item.base_image|regex_search('^http')
+      when: item.base_image | regex_search('^http')
 
     - name: make a copy of the base image to use with this instance
       synchronize:
         src: "{{ item.base_image }}"
         dest: "{{ img_path }}"
-      when: not item.base_image|regex_search('^http')
+      when: not (item.base_image | regex_search('^http'))
 
-    - name: configure instance image
-      shell: >
+    - name: upload files to image   # noqa 305
+      ansible.builtin.shell: >
+        virt-customize -a {{ img_path }} --upload
+        {{ file_item.local_path }}:{{ file_item.remote_path }}
+      with_items:
+        - "{{ item.upload_files }}"
+      loop_control:
+        loop_var: file_item
+      when: item.upload_files is defined
+
+    - name: configure instance image   # noqa 305
+      ansible.builtin.shell: >
         virt-customize -a {{ img_path }}
         --run-command 'mkdir -p /etc/cloud && touch
         /etc/cloud/cloud-init.disabled && useradd
@@ -56,13 +67,13 @@
       when: config_vm
       no_log: true
 
-    - name: run selinux-relabel
-      shell: "virt-customize -a {{ img_path }} --selinux-relabel"
+    - name: run selinux-relabel   # noqa 305
+      ansible.builtin.shell: >
+        virt-customize -a {{ img_path }} --selinux-relabel
       when: selinux_relabel
 
     - name: create the instace
       virt:
-        name: "{{ vm_name }}"
         command: define
         xml: "{{ lookup('template', 'vm.xml.j2') }}"
   when: not img_stat.stat.exists
@@ -72,8 +83,9 @@
     name: "{{ vm_name }}"
     state: running
 
-- name: get the IP
-  shell: "virsh domifaddr {{ vm_name }} | grep ipv4 | awk '{print $4}'"
+- name: get the IP   # noqa risky-shell-pipe 305
+  ansible.builtin.shell: >
+    virsh domifaddr {{ vm_name }} | grep ipv4 | awk '{print $4}'
   register: ip_out
   until: ip_out.stdout_lines|length > 0
   delay: 3
@@ -83,7 +95,7 @@
     LIBVIRT_DEFAULT_URI: "qemu:///system"
 
 - name: wait until the instance can be reached over SSH
-  wait_for:
+  ansible.builtin.wait_for:
     delay: 0
     sleep: 3
     port: 22
@@ -91,11 +103,11 @@
     search_regex: OpenSSH
 
 - name: attach additional disks
-  shell: |
+  ansible.builtin.shell: |
     truncate -s {{ disk.value }} {{ img_path[:-6] }}-{{ disk.key }}.img
     virsh attach-disk {{ vm_name }} {{ img_path[:-6] }}-{{ disk.key }}.img \
     {{ disk.key }} --driver qemu --subdriver raw --targetbus virtio --persistent
-  loop: "{{ query('dict', item.extra_vol|default({})) }}"
+  loop: "{{ query('dict', item.extra_vol | default({})) }}"
   loop_control:
     loop_var: disk
   environment:
@@ -103,24 +115,26 @@
   when: item.extra_vol is defined
 
 - name: create the basic instance hash
-  set_fact:
-    instance_dict: "{{ instance_dict|default({})|combine({
-      'user':vm_user,
-      'instance':item.name,
-      'address':ip_out.stdout_lines[0][:-3],
-      'port':item.port|default('22'),
-      'identity_file':item.id_file|default(
-         lookup('env','HOME') + '/.ssh/id_rsa') })}}"
+  ansible.builtin.set_fact:
+    instance_dict: "{{ instance_dict | default({}) | combine({
+      'user': vm_user,
+      'instance': item.name,
+      'address': ip_out.stdout_lines[0][:-3],
+      'port': item.port | default('22'),
+      'identity_file': item.id_file | default(
+         lookup('env', 'HOME') + '/.ssh/id_rsa') }) }}"
 
 - name: include become details in hash
-  set_fact:
-    instance_dict: "{{ instance_dict|combine({
-      'become_method':item.become_method|
-         default(molecule_yml.driver.become_method)|default('su'),
-      'become_pass':root_pass })}}"
-  when: config_vm or item.become_method is defined or item.become_pass is defined
+  ansible.builtin.set_fact:
+    instance_dict: "{{ instance_dict | combine({
+      'become_method': item.become_method |
+         default(molecule_yml.driver.become_method) | default('su'),
+      'become_pass': root_pass }) }}"
+  when: config_vm or item.become_method is defined or
+    item.become_pass is defined
   no_log: true
 
 - name: add instance to instances dictionary
-  set_fact:
-    instance_conf_dict: "{{ instance_conf_dict|default([]) + [ instance_dict ] }}"
+  ansible.builtin.set_fact:
+    instance_conf_dict: "{{ instance_conf_dict |
+      default([]) + [ instance_dict ] }}"

--- a/files/destroy_vm.yml
+++ b/files/destroy_vm.yml
@@ -11,12 +11,14 @@
     command: undefine
   failed_when: false
 
-- find:
+- name: find VM image path
+  ansible.builtin.find:
     path: "{{ molecule_yml.driver.images_path }}"
     patterns: "{{ vm_name }}*"
   register: del_files
 
-- file:
+- name: remove VM image
+  ansible.builtin.file:
     path: "{{ file.path }}"
     state: absent
   loop: "{{ del_files.files }}"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,6 +1,5 @@
 ---
-scenario:
-  name: default
+
 driver:
   name: delegated
   qemu_path: /usr/bin/qemu-system-x86_64
@@ -9,21 +8,29 @@ platforms:
   - name: centos7
     selinux_relabel: true
     base_image: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
-provisioner:
-  name: ansible
+  - name: ubuntu2004
+    config_vm: True
+    base_image: https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64-disk-kvm.img
+    upload_files:
+      - local_path: files/50-cloud-init.yaml
+        remote_path: /etc/netplan/50-cloud-init.yaml
+scenario:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-    converge: playbook.yml
-  lint:
-    name: ansible-lint
-lint:
-  name: yamllint
+    converge: converge.yml
+provisioner:
+  name: ansible
+  env:
+    PY_COLORS: '1'
+    ANSIBLE_FORCE_COLOR: '1'
+lint: |
+    export PY_COLORS=1
+    export ANSIBLE_FORCE_COLOR=1
+    yamllint .
+    ansible-lint .
+    flake8 .
 verifier:
   name: testinfra
   env:
     PYTHONWARNINGS: "ignore:.*U.*mode is deprecated:DeprecationWarning"
-  lint:
-    name: flake8
-  options:
-    v: 1


### PR DESCRIPTION
- Copy file(s) to virtual machine image option has been added: e.g. Canonical [cloud images](https://cloud-images.ubuntu.com/releases/) (like Ubuntu18.04 or 20.04) ships without netplan config to bring up ethernet interfaces, so you can upload them.
- Minor code style changes according to ansible-lint, removed deprecated options (especially molecule.yml old structure).